### PR TITLE
Use Steam Environment when launching on Linux

### DIFF
--- a/ofjam/gui.py
+++ b/ofjam/gui.py
@@ -745,6 +745,8 @@ class Ui_MainWindow(object):
         if platform.startswith('win32'):
             run("start /d \"{}\" hl2.exe -game \"{}\" -secure -steam {}".format(sdk,game,self.launchoptionsbox.text()), shell=True)
         else:
+            # Needed to run under the Steam Runtime
+            os.environ["SteamEnv"] = "1"
             #hl2 = "{sdk}\hl2_linux".format(sdk = sdkPath)
             #run([hl2, "-game", ofpath])
             Popen("\"{}/hl2.sh\" -game {} -secure -steam {}".format(sdk,game,self.launchoptionsbox.text()), shell=True)


### PR DESCRIPTION
Source tries to load a special locale that is only present within the steam runtime.
This solution starts OF within the Steam Runtime.